### PR TITLE
Added 'cd api' to documentation

### DIFF
--- a/api/README.md
+++ b/api/README.md
@@ -5,6 +5,7 @@
   3. Build and run the Docker container
         ```
         $ git submodule update --init
+        $ cd api
         $ docker build . -f Dockerfile.base -t rustla2-api-base
         $ docker build . -t rustla2-api
         $ docker run -d --name rustla2 --net=host -v ~/Rustla2:/Rustla2:rw -w /Rustla2 rustla2-api:latest


### PR DESCRIPTION
User needs to be in the `api` directory to run the docker commands. 