### PR TITLE
Add command for generating JWT secret on macOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,12 @@ Edit `.env` to change various environment variables. Most importantly,
 $ sed -i "s/JWT_SECRET=/JWT_SECRET=$(head -c 22 /dev/urandom | base64 | tr -dc A-Za-z0-9)/" .env
 ```
 
+The command is a little different on macOS:
+
+```bash
+$ sed -i "" "s/JWT_SECRET=/JWT_SECRET=$(head -c 22 /dev/urandom | base64 | tr -dc A-Za-z0-9)/" .env
+```
+
 Install dependencies and build the frontend:
 
 ``` bash


### PR DESCRIPTION
Part of the setup process involves using `sed` to generate a JWT secret, but the command fails on macOS.

```bash 
$ sed -i "s/JWT_SECRET=/JWT_SECRET=$(head -c 22 /dev/urandom | base64 | tr -dc A-Za-z0-9)/" .env
sed: 1: ".env": invalid command code .
```

This happens because `sed` on macOS requires you to specify an extension for an automatically-created backup file when editing a file in place with `-i`. When using `-i ""`, however, no backup is created and the command executes without issue.

```bash
$ sed -i "" "s/JWT_SECRET=/JWT_SECRET=$(head -c 22 /dev/urandom | base64 | tr -dc A-Za-z0-9)/" .env
```

I added this to the README to make the setup process easier for macfriends.

