### PR TITLE
Show hidden streams

### DIFF
--- a/api/README.md
+++ b/api/README.md
@@ -25,7 +25,7 @@ without the need to go through the Twitch OAuth setup.
      after first running the server):
         ```
         $ sqlite3 ./overrustle.sqlite
-        sqlite> INSERT INTO "users" VALUES('13374242-1337-1337-1337-cccccccccccc',1337,'testuser','testuser','','twitch','admin','','2018-04-16 19:53:02',0,0,'','2018-04-01 20:00:00','2018-04-11 20:00:00',0);
+        sqlite> INSERT INTO "users" VALUES('13374242-1337-1337-1337-cccccccccccc',1337,'testuser','testuser','','twitch','admin','','2018-04-16 19:53:02',0,0,'','2018-04-01 20:00:00','2018-04-11 20:00:00',0,0);
         ```
   2. Forge the correct jwt cookie to be able to access this account:
         ```

--- a/api/src/APIHTTPService.cpp
+++ b/api/src/APIHTTPService.cpp
@@ -17,7 +17,8 @@ APIHTTPService::APIHTTPService(std::shared_ptr<DB> db) : db_(db) {
           "stream_path": {"type": "string"},
           "service": {"type": "string"},
           "channel": {"type": "string"},
-          "left_chat": {"type": "boolean"}
+          "left_chat": {"type": "boolean"},
+          "show_hidden": {"type": "boolean"}
         },
         "required": ["username", "stream_path", "service", "channel"]
       }
@@ -111,6 +112,10 @@ void APIHTTPService::PostProfile(uWS::HttpResponse *res, HTTPRequest *req) {
 
     if (input.HasMember("left_chat")) {
       newUser->SetLeftChat(input["left_chat"].GetBool());
+    }
+
+    if (input.HasMember("show_hidden")) {
+      newUser->SetShowHidden(input["show_hidden"].GetBool());
     }
 
     auto name = json::StringRef(input["username"]);

--- a/api/src/Users.h
+++ b/api/src/Users.h
@@ -27,7 +27,7 @@ class User {
   User(sqlite::database db, const boost::uuids::uuid id,
        const int64_t twitch_id, const std::string &name, const Channel &channel,
        const std::string &last_ip, const time_t last_seen, const bool left_chat,
-       const bool is_admin)
+       const bool is_admin, const bool show_hidden)
       : db_(db),
         id_(id),
         twitch_id_(twitch_id),
@@ -36,7 +36,8 @@ class User {
         last_ip_(last_ip),
         last_seen_(last_seen),
         left_chat_(left_chat),
-        is_admin_(is_admin) {}
+        is_admin_(is_admin),
+        show_hidden_(show_hidden) {}
 
   User(sqlite::database db, const uint64_t twitch_id, const Channel &channel,
        const std::string &last_ip)
@@ -47,7 +48,8 @@ class User {
         last_ip_(last_ip),
         last_seen_(time(nullptr)),
         left_chat_(false),
-        is_admin_(false) {}
+        is_admin_(false),
+        show_hidden_(false) {}
 
   User(const User &user)
       : db_(user.db_),
@@ -58,7 +60,8 @@ class User {
         last_ip_(user.last_ip_),
         last_seen_(user.last_seen_),
         left_chat_(user.left_chat_),
-        is_admin_(user.is_admin_) {}
+        is_admin_(user.is_admin_),
+        show_hidden_(user.show_hidden_) {}
 
   inline boost::uuids::uuid GetID() {
     boost::shared_lock<boost::shared_mutex> read_lock(lock_);
@@ -105,6 +108,11 @@ class User {
     return is_admin_;
   }
 
+  inline bool GetShowHidden() {
+    boost::shared_lock<boost::shared_mutex> read_lock(lock_);
+    return show_hidden_;
+  }
+
   std::string GetStreamJSON();
 
   std::string GetUsernameJSON();
@@ -123,6 +131,8 @@ class User {
 
   bool SetLastSeen(const time_t last_seen);
 
+  bool SetShowHidden(bool show_hidden);
+
   bool Save();
 
   bool SaveNew();
@@ -138,6 +148,7 @@ class User {
   time_t last_seen_;
   bool left_chat_;
   bool is_admin_;
+  bool show_hidden_;
 
   friend class Users;
   friend std::ostream &operator<<(std::ostream &os, const User &user);

--- a/src/components/Profile.jsx
+++ b/src/components/Profile.jsx
@@ -37,6 +37,7 @@ const Profile = ({
               stream_path: event.target.elements.stream_path.value,
               username: event.target.elements.username.value,
               left_chat: event.target.elements.left_chat.checked,
+              show_hidden: event.target.elements.show_hidden.checked,
             };
             // Disallow blank inputs. The ORM will disallow these anyways but
             // there's arguably no point in even making the request if it's known
@@ -105,6 +106,16 @@ const Profile = ({
                 defaultChecked={profile.data.left_chat}
               />
               <label htmlFor='profile-leftchat' className='form-check-label'>Use Left Chat</label>
+            </div>
+          </div>
+          <div className='form-group'>
+            <div className='form-check'>
+              <Checkbox
+                id='profile-showhidden'
+                name='show_hidden'
+                defaultChecked={profile.data.show_hidden}
+              />
+              <label htmlFor='profile-showhidden' className='form-check-label'>Show Hidden Streams</label>
             </div>
           </div>
           <button type='submit' className='btn btn-primary' disabled={profile.isFetching}>Save Changes</button>


### PR DESCRIPTION
Adds a `show_hidden` property to `User` and a checkbox to toggle it from the profile page (disabled by default). If enabled, hidden streams aren't filtered from the homepage.

I used `left_chat` as a reference when working on this because it makes sense that the two should function similarly.

In order to access `show_hidden` from the Streams component, I had it fetch the profile state in the exact same way as it's done in Stream. Not sure if this is the best approach. 😶