### PR TITLE
suggest `npm ci` instead of `npm install`

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ $ sed -i "" "s/JWT_SECRET=/JWT_SECRET=$(head -c 22 /dev/urandom | base64 | tr -d
 Install dependencies and build the frontend:
 
 ``` bash
-$ npm install
+$ npm ci
 $ npm run build
 ```
 


### PR DESCRIPTION
This should result in a faster install-from-scratch.