### PR TITLE
add bot flag and per channel chat configs

### DIFF
--- a/api/src/APIHTTPService.cpp
+++ b/api/src/APIHTTPService.cpp
@@ -17,11 +17,20 @@ APIHTTPService::APIHTTPService(std::shared_ptr<DB> db) : db_(db) {
           "stream_path": {"type": "string"},
           "service": {"type": "string"},
           "channel": {"type": "string"},
+          "chat_service": {"type": "string"},
+          "chat_channel": {"type": "string"},
           "left_chat": {"type": "boolean"},
           "show_hidden": {"type": "boolean"},
           "show_dgg_chat": {"type": "boolean"}
         },
-        "required": ["username", "stream_path", "service", "channel"]
+        "required": [
+          "username",
+          "stream_path",
+          "service",
+          "channel",
+          "chat_service",
+          "chat_channel"
+        ]
       }
     )json");
 }
@@ -138,6 +147,12 @@ void APIHTTPService::PostProfile(uWS::HttpResponse *res, HTTPRequest *req) {
       newUser->SetChannel(Channel::Create(
           json::StringRef(input["channel"]), json::StringRef(input["service"]),
           json::StringRef(input["stream_path"]), &status));
+    }
+
+    if (status.Ok()) {
+      newUser->SetChatChannel(
+          Channel::Create(json::StringRef(input["chat_channel"]),
+                          json::StringRef(input["chat_service"]), &status));
     }
 
     if (status.Ok()) {

--- a/api/src/AdminHTTPService.cpp
+++ b/api/src/AdminHTTPService.cpp
@@ -26,7 +26,8 @@ AdminHTTPService::AdminHTTPService(std::shared_ptr<DB> db) : db_(db) {
           "nsfw": {"type": "boolean"},
           "hidden": {"type": "boolean"},
           "afk": {"type": "boolean"},
-          "promoted": {"type": "boolean"}
+          "promoted": {"type": "boolean"},
+          "bot": {"type": "boolean"}
         }
       }
     )json");
@@ -181,6 +182,9 @@ void AdminHTTPService::PostStream(uWS::HttpResponse *res, HTTPRequest *req) {
     }
     if (input.HasMember("promoted")) {
       stream->SetPromoted(input["promoted"].GetBool());
+    }
+    if (input.HasMember("bot")) {
+      stream->SetBot(input["bot"].GetBool());
     }
 
     if (stream->Save()) {

--- a/api/src/AuthHTTPService.cpp
+++ b/api/src/AuthHTTPService.cpp
@@ -89,7 +89,7 @@ void AuthHTTPService::GetOAuth(uWS::HttpResponse *res, HTTPRequest *req) {
   auto user = db_->GetUsers()->GetByTwitchID(twitch_id);
   if (user == nullptr) {
     auto channel = Channel::Create(twitch_name, kTwitchService.toString());
-    user = db_->GetUsers()->Emplace(twitch_id, channel, ip);
+    user = db_->GetUsers()->Emplace(twitch_id, channel, channel, ip);
   } else {
     user->SetLastIP(ip);
     user->Save();

--- a/api/src/Channel.h
+++ b/api/src/Channel.h
@@ -25,12 +25,14 @@ constexpr folly::StringPiece kUstreamService{"ustream"};
 constexpr folly::StringPiece kVaughnService{"vaughn"};
 constexpr folly::StringPiece kYouTubePlaylistService{"youtube-playlist"};
 constexpr folly::StringPiece kYouTubeService{"youtube"};
+constexpr folly::StringPiece kStrimsService{"strims"};
 
-constexpr std::array<folly::StringPiece, 12> kServices{
-    kAdvancedService,        kAngelThumpService,      kFacebookService,
-    kM3u8Service,            kMixerService,           kSmashcastService,
-    kTwitchService,          kTwitchVODService,       kUstreamService,
-    kVaughnService,          kYouTubePlaylistService, kYouTubeService};
+constexpr std::array<folly::StringPiece, 13> kServices{
+    kAdvancedService, kAngelThumpService,      kFacebookService,
+    kM3u8Service,     kMixerService,           kSmashcastService,
+    kTwitchService,   kTwitchVODService,       kUstreamService,
+    kVaughnService,   kYouTubePlaylistService, kYouTubeService,
+    kStrimsService};
 
 constexpr std::array<folly::StringPiece, 3> kCaseInsensitiveServices{
     kAngelThumpService, kTwitchService, kUstreamService};

--- a/api/src/Streams.cpp
+++ b/api/src/Streams.cpp
@@ -317,8 +317,9 @@ void Streams::WriteStreamsJSON(
   writer->EndArray();
 }
 
-std::shared_ptr<Stream> Streams::Emplace(const Channel &channel) {
-  auto stream = std::make_shared<Stream>(db_, channel, channel);
+std::shared_ptr<Stream> Streams::Emplace(const Channel &channel,
+                                         const Channel &chat_channel) {
+  auto stream = std::make_shared<Stream>(db_, channel, chat_channel);
 
   {
     boost::unique_lock<boost::shared_mutex> write_lock(lock_);

--- a/api/src/Streams.cpp
+++ b/api/src/Streams.cpp
@@ -163,8 +163,6 @@ bool Stream::SaveNew() {
           ?,
           ?,
           ?,
-          ?,
-          ?,
           datetime(),
           datetime()
         )

--- a/api/src/Streams.h
+++ b/api/src/Streams.h
@@ -368,7 +368,8 @@ class Streams {
     return it == data_by_channel_.end() ? nullptr : it->second;
   }
 
-  std::shared_ptr<Stream> Emplace(const Channel &channel);
+  std::shared_ptr<Stream> Emplace(const Channel &channel,
+                                  const Channel &chat_channel);
 
  private:
   sqlite::database db_;

--- a/api/src/WSService.cpp
+++ b/api/src/WSService.cpp
@@ -247,7 +247,7 @@ inline void WSService::SetStreamToChannel(
     return;
   }
 
-  SetStreamToChannel(stream_channel, writer, stream_id);
+  SetStreamToChannel(stream_channel, stream_channel, writer, stream_id);
 }
 
 /**
@@ -270,7 +270,7 @@ void WSService::SetStreamToStreamPath(
     return;
   }
 
-  SetStreamToChannel(*channel, writer, stream_id);
+  SetStreamToChannel(*channel, *user->GetChatChannel(), writer, stream_id);
 }
 
 /**
@@ -279,8 +279,8 @@ void WSService::SetStreamToStreamPath(
  * TODO: this should probably be the model's responsibility...
  */
 void WSService::SetStreamToChannel(
-    const Channel& channel, rapidjson::Writer<rapidjson::StringBuffer>* writer,
-    uint64_t* stream_id) {
+    const Channel& channel, const Channel& chat_channel,
+    rapidjson::Writer<rapidjson::StringBuffer>* writer, uint64_t* stream_id) {
   if (db_->GetBannedStreams()->Contains(channel)) {
     writer->String("STREAM_BANNED");
     writer->Null();
@@ -289,7 +289,7 @@ void WSService::SetStreamToChannel(
 
   auto stream = db_->GetStreams()->GetByChannel(channel);
   if (stream == nullptr) {
-    stream = db_->GetStreams()->Emplace(channel);
+    stream = db_->GetStreams()->Emplace(channel, chat_channel);
   }
 
   writer->String("STREAM_SET");

--- a/api/src/WSService.h
+++ b/api/src/WSService.h
@@ -49,7 +49,7 @@ class WSService {
                              rapidjson::Writer<rapidjson::StringBuffer>* writer,
                              uint64_t* stream_id);
 
-  void SetStreamToChannel(const Channel& channel,
+  void SetStreamToChannel(const Channel& channel, const Channel& chat_channel,
                           rapidjson::Writer<rapidjson::StringBuffer>* writer,
                           uint64_t* stream_id);
 

--- a/api/tests/UsersTest.cpp
+++ b/api/tests/UsersTest.cpp
@@ -14,11 +14,12 @@ TEST(UsersTest, TestSetName) {
   sqlite::database db(":memory:");
 
   auto channel = Channel::Create("twitch", "test");
+  auto chat_channel = Channel::Create("strims", "");
 
   auto names = std::vector<std::string>{"InfiniteJester", "beepybeepy",
                                         "SpiderTechnitian"};
   for (const auto &name : names) {
-    User user(db, 1, channel, "10.0.0.1");
+    User user(db, 1, channel, chat_channel, "10.0.0.1");
     auto status = user.SetName(name);
     LOG(INFO) << status.GetErrorMessage();
     EXPECT_TRUE(status.Ok());


### PR DESCRIPTION
adds a flag to streams so we can move bots into their own category without losing them in the live streams section. 

adds config fields for chat channel/service so users can choose a chat to show with their stream.