### PR TITLE
move fetch and Promise polyfills to their own chunk

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5141,6 +5141,12 @@
         "uglify-js": "3.4.x"
       }
     },
+    "html-webpack-exclude-assets-plugin": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/html-webpack-exclude-assets-plugin/-/html-webpack-exclude-assets-plugin-0.0.7.tgz",
+      "integrity": "sha512-gaYKMGBPDts3Fb1WXyDEEcS/0TSRg2IDl3EsbQL2AkKWTqdjSKwfQ8Iz0RhPiWErJfqhq5/wkhoYyjQoG55pug==",
+      "dev": true
+    },
     "html-webpack-plugin": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/html-webpack-plugin/-/html-webpack-plugin-3.2.0.tgz",

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "file-loader": "^2.0.0",
     "flow-bin": "^0.104.0",
     "helper-git-hash": "^1.0.0",
+    "html-webpack-exclude-assets-plugin": "0.0.7",
     "html-webpack-plugin": "^3.1.0",
     "lodash-webpack-plugin": "^0.11.5",
     "mini-css-extract-plugin": "^0.4.0",

--- a/src/client.jsx
+++ b/src/client.jsx
@@ -1,4 +1,3 @@
-global.Promise = require('bluebird');
 import React from 'react';
 import { render } from 'react-dom';
 

--- a/src/index.ejs
+++ b/src/index.ejs
@@ -12,5 +12,18 @@
   </head>
   <body>
     <div id="main" class="jiggle-background"></div>
+    <script
+      nomodule
+      src="<%= htmlWebpackPlugin.files.chunks['polyfills'].entry %>"
+      <% if (htmlWebpackPlugin.files.jsIntegrity) { %> integrity="<%= htmlWebpackPlugin.files.jsIntegrity[0] %>" <% } %>
+      crossorigin="<%= webpackConfig.output.crossOriginLoading %>"
+    >
+    </script>
+    <script
+      src="<%= htmlWebpackPlugin.files.chunks['main'].entry %>"
+      <% if (htmlWebpackPlugin.files.jsIntegrity) { %> integrity="<%= htmlWebpackPlugin.files.jsIntegrity[1] %>" <% } %>
+      crossorigin="<%= webpackConfig.output.crossOriginLoading %>"
+    >
+    </script>
   </body>
 </html>

--- a/src/polyfills.js
+++ b/src/polyfills.js
@@ -1,0 +1,9 @@
+// @flow
+
+if (!global.Promise) {
+  global.Promise = require('bluebird');
+}
+
+if (!global.fetch) {
+  global.fetch = require('isomorphic-fetch');
+}

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -7,6 +7,7 @@ const MiniCssExtractPlugin = require('mini-css-extract-plugin');
 const gitHash = require('helper-git-hash');
 const UglifyJsPlugin = require('uglifyjs-webpack-plugin');
 const LodashWebpackPlugin = require('lodash-webpack-plugin');
+const HtmlWebpackExcludeAssetsPlugin = require('html-webpack-exclude-assets-plugin');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
 
 const { NODE_ENV } = process.env;
@@ -19,12 +20,12 @@ module.exports = {
   mode: IS_PRODUCTION ? 'production' : 'development',
   devtool: !IS_PRODUCTION && 'eval-source-map',
   entry: {
+    polyfills: path.resolve(__dirname, 'src/polyfills.js'),
     main: [
       '@babel/polyfill',
-      'isomorphic-fetch',
       path.resolve(__dirname, 'src/css/main.scss'),
       path.resolve(__dirname, 'src/client.jsx'),
-    ],
+    ]
   },
   output: {
     path: path.resolve(__dirname, './public/assets'),
@@ -117,9 +118,8 @@ module.exports = {
   },
   plugins: [
     new HtmlWebpackPlugin({
-      template: './src/index.ejs',
+      excludeAssets: [/(main|polyfills)(\..*)?\.js$/],
       filename: '../index.html',
-      chunksSortMode: 'none',
       inject: true,
       minify: IS_PRODUCTION && {
         collapseWhitespace: true,
@@ -128,7 +128,9 @@ module.exports = {
         removeScriptTypeAttributes: true,
         removeStyleLinkTypeAttributes: true,
       },
+      template: './src/index.ejs',
     }),
+    new HtmlWebpackExcludeAssetsPlugin(),
     new (require('webpack-subresource-integrity'))({
       hashFuncNames: ['sha256', 'sha384'],
       enabled: IS_PRODUCTION,


### PR DESCRIPTION
This patch moves the `fetch` and `Promise` polyfills to their own chunk.
In order to conditionally load this chunk only on browsers that actually
need them, the `nomodule` attribute of `<script>` tags is used.

Closes https://github.com/MemeLabs/Rustla2/issues/38