### PR TITLE
Backend ci cd

### DIFF
--- a/.github/workflows/backend-cd.yml
+++ b/.github/workflows/backend-cd.yml
@@ -1,19 +1,14 @@
-name: Backend build
+name: Backend Continuous Deployment
 on:
   push:
     paths:
-      - '.github/workflows/backend.yml'
+      - '.github/workflows/backend-cd.yml'
       - 'api/**'
       - '!api/.gitignore'
       - '!api/README.md'
       - '.gitmodules'
-  pull_request:
-    paths:
-      - '.github/workflows/backend.yml'
-      - 'api/**'
-      - '!api/.gitignore'
-      - '!api/README.md'
-      - '.gitmodules'
+    branches:
+      - 'master'
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -1,0 +1,42 @@
+name: Backend Continuous Integration
+on:
+  pull_request:
+    paths:
+      - '.github/workflows/backend-ci.yml'
+      - 'api/**'
+      - '!api/.gitignore'
+      - '!api/README.md'
+      - '.gitmodules'
+  push:
+    paths:
+      - '.github/workflows/backend-ci.yml'
+      - 'api/**'
+      - '!api/.gitignore'
+      - '!api/README.md'
+      - '.gitmodules'
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+      with:
+        submodules: true
+        
+    - name: Build API image
+      env:
+        DOCKER_BUILDKIT: 1  
+      run: cd ./api && docker build . -t docker.pkg.github.com/memelabs/rustla2/rustla2-api:latest
+    - name: Download container structure test binary
+      uses: fnkr/github-action-git-bash@v1
+      with:
+        args: "wget -O ./api/container-structure-test https://storage.googleapis.com/container-structure-test/latest/container-structure-test-linux-amd64"
+     
+    - name: Chmod
+      uses: fnkr/github-action-git-bash@v1
+      with:
+        args: "chmod +x ./api/container-structure-test"
+    
+    - name: Test image
+      uses: fnkr/github-action-git-bash@v1
+      with:
+        args: "./api/container-structure-test test --image docker.pkg.github.com/memelabs/rustla2/rustla2-api:latest --config ./api/container_test.yaml"


### PR DESCRIPTION
Separates backend workflow into CI and CD so that we only publish the image to the repository on merged PR's into master