### PR TITLE
Make container test function properly

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -112,7 +112,7 @@ WORKDIR /api
 COPY --from=base /api/build/rustla2_api .
 
 RUN apt-get update && apt-get install -y \
-    libmagic-dev
+    libmagic-dev curl
 
 RUN useradd -m rustla
 USER rustla

--- a/api/container_test.yaml
+++ b/api/container_test.yaml
@@ -2,7 +2,17 @@ schemaVersion: "2.0.0"
 
 commandTests:
   - name: "Startup test"
-    command: "/api/rustla2_api"
-    args: ["--alsologtostderr"]
-    expectedError: ["loading config from .env"]
-    exitCode: 139
+    command: "/bin/bash"
+    args: ["-c", "cd ~ && touch .env && mkdir public && \
+    printf 'API=/api\nSCALA_API=/scala-api\nAPI_WS=\nAFK_TIMEOUT=7200000\nDB_DB=overrustle\nDB_PATH=./overrustle.sqlite\nDONATE_DO_URL=\nDONATE_LINODE_URL=\nDONATE_PAYPAL_URL=\nGITHUB_URL=https://github.com/MemeLabs/Rustla2\nCHAT_URL=https://chat.strims.gg\nCHAT2_DOMAIN=\nCHAT2_URL=\nTHUMBNAIL_REFRESH_INTERVAL=60000\nJWT_SECRET=\nJWT_NAME=jwt\nJWT_DOMAIN=strims.gg\nJWT_TTL=2592000\nPORT=8076\nLIVECHECK_INTERVAL=60000\nTWITCH_CLIENT_ID=\nTWITCH_CLIENT_SECRET=\nTWITCH_REDIRECT_URI=https://example.com/\nEMOTE_SIMILARITY_MIN_LENGTH=4\nEMOTE_SUBSTRING_MIN_LENGTH=2\nEMOTE_SIMILARITY_PREFIX_CHECK_SIZE=2\nEMOTE_SIMILARITY_MIN_EDIT_DISTANCE=4\nEMOTES=ComfyDog,ApeHands,DumpsterFire\nIP_ADDRESS_HEADER=\"x-client-ip\"\nSTREAM_BROADCAST_INTERVAL=60000\nRUSTLER_BROADCAST_INTERVAL=100\nPUBLIC_PATH=./public\n' > .env && \
+    nohup /api/rustla2_api --alsologtostderr & sleep 5"]
+    expectedError: ["server thread"]
+    exitCode: 0
+
+  - name: "Connection test"
+    command: "/bin/bash"
+    args: ["-c", "cd ~ && touch .env && mkdir public && \
+    printf 'API=/api\nSCALA_API=/scala-api\nAPI_WS=\nAFK_TIMEOUT=7200000\nDB_DB=overrustle\nDB_PATH=./overrustle.sqlite\nDONATE_DO_URL=\nDONATE_LINODE_URL=\nDONATE_PAYPAL_URL=\nGITHUB_URL=https://github.com/MemeLabs/Rustla2\nCHAT_URL=https://chat.strims.gg\nCHAT2_DOMAIN=\nCHAT2_URL=\nTHUMBNAIL_REFRESH_INTERVAL=60000\nJWT_SECRET=\nJWT_NAME=jwt\nJWT_DOMAIN=strims.gg\nJWT_TTL=2592000\nPORT=8076\nLIVECHECK_INTERVAL=60000\nTWITCH_CLIENT_ID=\nTWITCH_CLIENT_SECRET=\nTWITCH_REDIRECT_URI=https://example.com/\nEMOTE_SIMILARITY_MIN_LENGTH=4\nEMOTE_SUBSTRING_MIN_LENGTH=2\nEMOTE_SIMILARITY_PREFIX_CHECK_SIZE=2\nEMOTE_SIMILARITY_MIN_EDIT_DISTANCE=4\nEMOTES=ComfyDog,ApeHands,DumpsterFire\nIP_ADDRESS_HEADER=\"x-client-ip\"\nSTREAM_BROADCAST_INTERVAL=60000\nRUSTLER_BROADCAST_INTERVAL=100\nPUBLIC_PATH=./public\n' > .env && \
+    /api/rustla2_api & sleep 5 && curl -s 0.0.0.0:8076/api"]
+    expectedOutput: ['{"stream_list":\[\],"streams":{}}']
+    exitCode: 0


### PR DESCRIPTION
Before I was doing some scuffed test that didn't test the binary properly, it now creates an .env file for the server to actually start and then does another test by calling the /api endpoint. I had to include an apt install curl in the Dockerfile to test the endpoint as you can't install any new packages in the image at runtime because the image run as an unprivileged user.

The gotcha with this was that when you mount ~/Rustla2 when running the docker image, if the ~/Rustla2/public folder doesn't exist it crashes, I guess the code never checks if the directory exists, I discovered this by deleting files and folders one by one from the mounted folder until it broke.

@slugalisk I'm not sure what happened today with the image you ran but I tested it locally and it worked fine, I think you might have missed something. The only difference that is obvious to me is that the rustla2_api binary is no longer copied into /usr/local/bin/ and as a result the entrypoint is ["/bin/bash", "-c", "/api/rustla2_api ${extraArgs} && sleep infinity"] 
Maybe if you give me more deets as to how you start it, I might be able to spot the issue.