### PR TITLE
remove `suppress_comment` from flow config

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -9,6 +9,5 @@
 
 [options]
 module.name_mapper='^.*\/css\/.*$' -> 'css-module-flow'
-suppress_comment= \\(.\\|\n\\)*\\$FlowFixMe
 
 [strict]


### PR DESCRIPTION
`suppress_comment` was removed from flow in favor of built-in,
standarized error suppressors (`$FlowFixMe` being one of them). This
change is a prerequisite for updating flow-bin (#308).