### PR TITLE
use bahmutov/npm-install to install npm dependencies

### DIFF
--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -19,7 +19,7 @@ jobs:
         npm install -g npm
         npm --version
     - name: Install dependencies
-      run: npm ci
+      uses: bahmutov/npm-install@v1.4.3
     - name: Build
       run: npm run build:production
     - name: Lint


### PR DESCRIPTION
This action will cache npm dependencies which can speed up future
builds.