### PR TITLE
use current location's hostname for twitch stream embed

### DIFF
--- a/src/components/StreamEmbed.jsx
+++ b/src/components/StreamEmbed.jsx
@@ -22,9 +22,9 @@ const getSrc = (channel: string, service: string): string | null => {
     case 'smashcast':
       return `https://www.smashcast.tv/embed/${channel}?popout=true&autoplay=true`;
     case 'twitch-vod':
-      return `https://player.twitch.tv/?video=v${channel}&parent=${location.host}`;
+      return `https://player.twitch.tv/?video=v${channel}&parent=${location.hostname}`;
     case 'twitch':
-      return `https://player.twitch.tv/?channel=${channel}&parent=${location.host}`;
+      return `https://player.twitch.tv/?channel=${channel}&parent=${location.hostname}`;
     case 'ustream':
       return `https://www.ustream.tv/embed/${channel}?autoplay=true&html5ui=true`;
     case 'vaughn':


### PR DESCRIPTION
`location.host` will contain the port number (if not the default), and
the colon (`:`) character is not a valid character in the `parent`
parameter. This issue is generally only evident during local
development.