### PR TITLE
expose existing created_at from db for usage in chat

### DIFF
--- a/api/src/Users.cpp
+++ b/api/src/Users.cpp
@@ -30,6 +30,8 @@ std::string User::GetUsernameJSON() {
   writer.StartObject();
   writer.Key("username");
   writer.String(name_);
+  writer.Key("created_at");
+  writer.Int(created_at_);
   writer.EndObject();
 
   return buf.GetString();
@@ -58,6 +60,8 @@ std::string User::GetProfileJSON() {
   writer.Bool(show_dgg_chat_);
   writer.Key("enable_public_state");
   writer.Bool(enable_public_state_);
+  writer.Key("created_at");
+  writer.Int(created_at_);
   writer.EndObject();
 
   return buf.GetString();
@@ -85,6 +89,8 @@ void User::WriteJSON(rapidjson::Writer<rapidjson::StringBuffer> *writer) {
   writer->Bool(show_dgg_chat_);
   writer->Key("enable_public_state");
   writer->Bool(enable_public_state_);
+  writer->Key("created_at");
+  writer->Int(created_at_);
   writer->EndObject();
 }
 
@@ -304,7 +310,8 @@ std::ostream &operator<<(std::ostream &os, const User &user) {
      << "is_admin: " << user.is_admin_ << ", "
      << "show_hidden: " << user.show_hidden_ << ", "
      << "show_dgg_chat: " << user.show_dgg_chat_ << ", "
-     << "enable_public_state: " << user.enable_public_state_;
+     << "enable_public_state: " << user.enable_public_state_ << ", "
+     << "created_at" << user.created_at_;
   return os;
 }
 
@@ -327,7 +334,8 @@ Users::Users(sqlite::database db) : db_(db) {
         `is_admin`,
         `show_hidden`,
         `show_dgg_chat`,
-        `enable_public_state`
+        `enable_public_state`,
+        `created_at`
       FROM `users`
     )sql";
   auto query = db_ << sql;
@@ -338,12 +346,13 @@ Users::Users(sqlite::database db) : db_(db) {
                const std::string &last_ip, const time_t last_seen,
                const bool left_chat, const bool is_admin,
                const bool show_hidden, const bool show_dgg_chat,
-               const bool enable_public_state) {
+               const bool enable_public_state, const time_t created_at) {
     boost::uuids::string_generator to_uuid;
     auto user_channel = Channel::Create(channel, service, stream_path);
     auto user = std::make_shared<User>(
         db_, to_uuid(id), twitch_id, name, user_channel, last_ip, last_seen,
-        left_chat, is_admin, show_hidden, show_dgg_chat, enable_public_state);
+        left_chat, is_admin, show_hidden, show_dgg_chat, enable_public_state,
+        created_at);
 
     data_by_id_[user->GetID()] = user;
     data_by_twitch_id_[user->GetTwitchID()] = user;

--- a/api/src/Users.h
+++ b/api/src/Users.h
@@ -28,7 +28,7 @@ class User {
        const int64_t twitch_id, const std::string &name, const Channel &channel,
        const std::string &last_ip, const time_t last_seen, const bool left_chat,
        const bool is_admin, const bool show_hidden, const bool show_dgg_chat,
-       const bool enable_public_state)
+       const bool enable_public_state, const time_t created_at)
       : db_(db),
         id_(id),
         twitch_id_(twitch_id),
@@ -40,7 +40,8 @@ class User {
         is_admin_(is_admin),
         show_hidden_(show_hidden),
         show_dgg_chat_(show_dgg_chat),
-        enable_public_state_(enable_public_state) {}
+        enable_public_state_(enable_public_state),
+        created_at_(created_at) {}
 
   User(sqlite::database db, const uint64_t twitch_id, const Channel &channel,
        const std::string &last_ip)
@@ -54,7 +55,8 @@ class User {
         is_admin_(false),
         show_hidden_(false),
         show_dgg_chat_(false),
-        enable_public_state_(true) {}
+        enable_public_state_(true),
+        created_at_(time(nullptr)) {}
 
   User(const User &user)
       : db_(user.db_),
@@ -68,7 +70,8 @@ class User {
         is_admin_(user.is_admin_),
         show_hidden_(user.show_hidden_),
         show_dgg_chat_(user.show_dgg_chat_),
-        enable_public_state_(user.enable_public_state_) {}
+        enable_public_state_(user.enable_public_state_),
+        created_at_(user.created_at_) {}
 
   inline boost::uuids::uuid GetID() {
     boost::shared_lock<boost::shared_mutex> read_lock(lock_);
@@ -130,6 +133,11 @@ class User {
     return enable_public_state_;
   }
 
+  inline time_t GetCreatedAt() {
+    boost::shared_lock<boost::shared_mutex> read_lock(lock_);
+    return created_at_;
+  }
+
   std::string GetStreamJSON();
 
   std::string GetUsernameJSON();
@@ -172,6 +180,7 @@ class User {
   bool show_hidden_;
   bool show_dgg_chat_;
   bool enable_public_state_;
+  time_t created_at_;
 
   friend class Users;
   friend std::ostream &operator<<(std::ostream &os, const User &user);


### PR DESCRIPTION
Extend current methods to utilize created_at and expose it over the
username endpoint for chat to set a feature on it's side.

current WIP, can't build locally due to docker issues. Trying to fix that
