### PR TITLE
Attempt to make stream cards more responsive when changing chat window size

### DIFF
--- a/src/components/Streams.jsx
+++ b/src/components/Streams.jsx
@@ -32,7 +32,7 @@ const Category = ({ header, streams }) => {
     .map((stream, i) => <Thumbnail key={i} {...stream} />);
 
   return (
-    <section className='px-4'>
+    <section className='px-3'>
       <h3 className='mt-4'>{header}</h3>
       <div className='streams-layout'>
         {thumbnails}

--- a/src/components/Streams.jsx
+++ b/src/components/Streams.jsx
@@ -16,9 +16,9 @@ import MainLayout from './MainLayout';
 import StreamThumbnail from './StreamThumbnail';
 
 const Thumbnail = stream => (
-  <div className='col-12 col-sm-4 col-md-3 col-lg-2' key={stream.id}>
+  <article key={stream.id}>
     <StreamThumbnail {...stream} />
-  </div>
+  </article>
 );
 
 const Category = ({ header, streams }) => {
@@ -32,10 +32,12 @@ const Category = ({ header, streams }) => {
     .map((stream, i) => <Thumbnail key={i} {...stream} />);
 
   return (
-    <div className='streams'>
-      <h3 className='col-12 mt-4'>{header}</h3>
-      {thumbnails}
-    </div>
+    <section className='px-4'>
+      <h3 className='mt-4'>{header}</h3>
+      <div className='streams-layout'>
+        {thumbnails}
+      </div>
+    </section>
   );
 };
 

--- a/src/css/Streams.scss
+++ b/src/css/Streams.scss
@@ -3,7 +3,8 @@
   text-align: center;
 }
 
-.streams {
-  display: flex;
-  flex-wrap: wrap;
+.streams-layout {
+  display: grid;
+  grid-gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
 }


### PR DESCRIPTION
This is a minor tweak to fix something that's bugged me about resizing the chat window, the stream thumbnails don't respond the shift in size.

Issue lies in media queries only responding to the browser window size and not the container size. So until [container queries](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Container_Queries) are a real thing, adding a responsive grid is the next best solution I could think of.

I'm not too familiar with bootstraps sizing so I hand rolled the css for this.

Before:
![Screenshot from 2021-10-12 22-26-31](https://user-images.githubusercontent.com/4275720/137072848-78b43c05-2435-45cb-b7d4-e42f995e1d5a.png)
After:
![Screenshot from 2021-10-12 22-24-37](https://user-images.githubusercontent.com/4275720/137072852-f81191b3-3229-4267-a026-d59b799e1f42.png)
