### PR TITLE
replace auto-fit for auto-fill

### DIFF
--- a/src/css/Streams.scss
+++ b/src/css/Streams.scss
@@ -6,5 +6,5 @@
 .streams-layout {
   display: grid;
   grid-gap: 1rem;
-  grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+  grid-template-columns: repeat(auto-fill, minmax(250px, 1fr));
 }


### PR DESCRIPTION
RE: https://github.com/MemeLabs/Rustla2/issues/222#issuecomment-942852889

Fixing issue with #342 where thumbnail cards would just grow/expand to fit the allotted area if they had the space.

This tweak will uses `auto-fill` which just creates empty grid areas if there's room so cards stay uniform.

https://user-images.githubusercontent.com/4275720/137251390-f6134f1f-7190-43b8-849a-c5730364f7a3.mp4

